### PR TITLE
[5주차] 분산락 적용 & 재고차감 보상 트랜잭션 처리

### DIFF
--- a/ecommerce-adapter/build.gradle.kts
+++ b/ecommerce-adapter/build.gradle.kts
@@ -19,4 +19,5 @@ dependencies {
 
     // TestContainer
     testImplementation ("org.testcontainers:mysql")
+    testImplementation ("com.redis:testcontainers-redis")
 }

--- a/ecommerce-adapter/src/main/kotlin/com/ecommerce/adapter/out/persistence/core/CouponPersistenceAdapter.kt
+++ b/ecommerce-adapter/src/main/kotlin/com/ecommerce/adapter/out/persistence/core/CouponPersistenceAdapter.kt
@@ -51,4 +51,7 @@ class CouponPersistenceAdapter(
         return couponMapper.toUserCoupon(saveUserCoupon)
     }
 
+    override fun rollbackUserCoupon(couponId: Long, userId: Long) {
+        userCouponJpaRepository.rollbackToAvailable(couponId, userId)
+    }
 }

--- a/ecommerce-adapter/src/main/kotlin/com/ecommerce/adapter/out/persistence/core/StockPersistenceAdapter.kt
+++ b/ecommerce-adapter/src/main/kotlin/com/ecommerce/adapter/out/persistence/core/StockPersistenceAdapter.kt
@@ -15,7 +15,7 @@ class StockPersistenceAdapter(
 ): StockPort {
 
     override fun findStockByItemId(itemId: Long): Stock {
-        val stock = jpaRepository.findByItemIdWithLock(itemId)
+        val stock = jpaRepository.findByItemId(itemId)
             .orElseThrow { CustomException(ErrorCode.ITEM_NOT_FOUND) }
 
         return stockMapper.toStock(stock)

--- a/ecommerce-adapter/src/main/kotlin/com/ecommerce/adapter/out/persistence/entity/UserCouponEntity.kt
+++ b/ecommerce-adapter/src/main/kotlin/com/ecommerce/adapter/out/persistence/entity/UserCouponEntity.kt
@@ -5,16 +5,23 @@ import jakarta.persistence.*
 import java.time.LocalDateTime
 
 @Entity
-@Table(name = "USER_COUPON")
+@Table(
+    name = "USER_COUPON",
+    uniqueConstraints = [
+        UniqueConstraint(columnNames = ["user_id", "coupon_id"])
+    ]
+)
 class UserCouponEntity(
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "user_coupon_id")
     val id: Long?,
 
+    @Column(name = "user_id", nullable = false)
     val userId: Long,
 
     @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "coupon_id", nullable = false)
     val coupon: CouponEntity,
 
     @Enumerated(EnumType.STRING)

--- a/ecommerce-adapter/src/main/kotlin/com/ecommerce/adapter/out/persistence/repository/CouponJpaRepository.kt
+++ b/ecommerce-adapter/src/main/kotlin/com/ecommerce/adapter/out/persistence/repository/CouponJpaRepository.kt
@@ -10,7 +10,6 @@ import java.util.Optional
 
 interface CouponJpaRepository: JpaRepository<CouponEntity, Long> {
 
-    @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("select c from CouponEntity c where c.id = :couponId")
     fun findByIdWithLock(@Param("couponId") couponId: Long): Optional<CouponEntity>
 

--- a/ecommerce-adapter/src/main/kotlin/com/ecommerce/adapter/out/persistence/repository/StockJpaRepository.kt
+++ b/ecommerce-adapter/src/main/kotlin/com/ecommerce/adapter/out/persistence/repository/StockJpaRepository.kt
@@ -10,7 +10,7 @@ import java.util.Optional
 
 interface StockJpaRepository: JpaRepository<StockEntity, Long> {
 
-    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    //@Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("select s from StockEntity s where s.itemId = :itemId")
     fun findByItemIdWithLock(@Param("itemId") itemId: Long): Optional<StockEntity>
 

--- a/ecommerce-adapter/src/main/kotlin/com/ecommerce/adapter/out/persistence/repository/StockJpaRepository.kt
+++ b/ecommerce-adapter/src/main/kotlin/com/ecommerce/adapter/out/persistence/repository/StockJpaRepository.kt
@@ -1,17 +1,11 @@
 package com.ecommerce.adapter.out.persistence.repository
 
 import com.ecommerce.adapter.out.persistence.entity.StockEntity
-import jakarta.persistence.LockModeType
 import org.springframework.data.jpa.repository.JpaRepository
-import org.springframework.data.jpa.repository.Lock
-import org.springframework.data.jpa.repository.Query
-import org.springframework.data.repository.query.Param
 import java.util.Optional
 
 interface StockJpaRepository: JpaRepository<StockEntity, Long> {
 
-    //@Lock(LockModeType.PESSIMISTIC_WRITE)
-    @Query("select s from StockEntity s where s.itemId = :itemId")
-    fun findByItemIdWithLock(@Param("itemId") itemId: Long): Optional<StockEntity>
+    fun findByItemId(itemId: Long): Optional<StockEntity>
 
 }

--- a/ecommerce-adapter/src/main/kotlin/com/ecommerce/adapter/out/persistence/repository/UserCouponJpaRepository.kt
+++ b/ecommerce-adapter/src/main/kotlin/com/ecommerce/adapter/out/persistence/repository/UserCouponJpaRepository.kt
@@ -2,6 +2,9 @@ package com.ecommerce.adapter.out.persistence.repository
 
 import com.ecommerce.adapter.out.persistence.entity.UserCouponEntity
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Modifying
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
 import java.util.Optional
 
 interface UserCouponJpaRepository: JpaRepository<UserCouponEntity, Long> {
@@ -9,5 +12,14 @@ interface UserCouponJpaRepository: JpaRepository<UserCouponEntity, Long> {
     fun findByCoupon_IdAndUserId(couponId: Long, userId: Long): Optional<UserCouponEntity>
 
     fun existsByCoupon_IdAndUserId(couponId: Long, userId: Long): Boolean
+
+    @Modifying
+    @Query("update UserCouponEntity uc " +
+            "set uc.status = 'AVAILABLE' " +
+            "where uc.coupon.id = :couponId and uc.userId = :userId and uc.status = 'USED'")
+    fun rollbackToAvailable(
+        @Param("couponId") couponId: Long,
+        @Param("userId") userId: Long
+    )
 
 }

--- a/ecommerce-adapter/src/main/resources/application-local.yml
+++ b/ecommerce-adapter/src/main/resources/application-local.yml
@@ -15,3 +15,8 @@ spring:
     properties:
       hibernate:
         dialect: org.hibernate.dialect.MySQL8Dialect
+
+  data:
+    redis:
+      host: localhost
+      port: 6379

--- a/ecommerce-adapter/src/test/kotlin/com/ecommerce/adapter/config/IntegrateTestSupport.kt
+++ b/ecommerce-adapter/src/test/kotlin/com/ecommerce/adapter/config/IntegrateTestSupport.kt
@@ -1,5 +1,6 @@
 package com.ecommerce.adapter.config
 
+import com.ecommerce.common.config.RedisCleanUp
 import org.junit.jupiter.api.BeforeEach
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
@@ -12,9 +13,13 @@ class IntegrateTestSupport {
     @Autowired
     private lateinit var databaseCleanUp: DatabaseCleanUp
 
+    @Autowired
+    private lateinit var redisCleanUp: RedisCleanUp
+
     @BeforeEach
     fun execute() {
         databaseCleanUp.execute()
+        redisCleanUp.execute()
     }
 
 }

--- a/ecommerce-adapter/src/test/kotlin/com/ecommerce/adapter/config/TestContainerConfig.kt
+++ b/ecommerce-adapter/src/test/kotlin/com/ecommerce/adapter/config/TestContainerConfig.kt
@@ -1,5 +1,6 @@
 package com.ecommerce.adapter.config
 
+import com.redis.testcontainers.RedisContainer
 import jakarta.annotation.PreDestroy
 import org.springframework.context.annotation.Configuration
 import org.testcontainers.containers.MySQLContainer
@@ -12,10 +13,14 @@ class TestContainerConfig {
         if (MYSQL_CONTAINER!!.isRunning()) {
             MYSQL_CONTAINER!!.stop()
         }
+        if (REDIS_CONTAINER!!.isRunning()) {
+            REDIS_CONTAINER!!.stop()
+        }
     }
 
     companion object {
         var MYSQL_CONTAINER: MySQLContainer<*>? = null
+        var REDIS_CONTAINER: RedisContainer? = null
 
         init {
             // mysql
@@ -29,6 +34,15 @@ class TestContainerConfig {
             System.setProperty("spring.datasource.url", MYSQL_CONTAINER!!.getJdbcUrl() + "?characterEncoding=UTF-8&serverTimezone=UTC")
             System.setProperty("spring.datasource.username", MYSQL_CONTAINER!!.getUsername())
             System.setProperty("spring.datasource.password", MYSQL_CONTAINER!!.getPassword())
+
+            // redis
+            REDIS_CONTAINER = RedisContainer(DockerImageName.parse("redis:6.2"))
+                .apply {
+                    withExposedPorts(6379)
+                }
+            REDIS_CONTAINER!!.start()
+            System.setProperty("spring.data.redis.host", REDIS_CONTAINER!!.host)
+            System.setProperty("spring.data.redis.port", REDIS_CONTAINER!!.getMappedPort(6379).toString())
         }
     }
 }

--- a/ecommerce-adapter/src/test/kotlin/com/ecommerce/adapter/usecase/OrderUseCaseTest.kt
+++ b/ecommerce-adapter/src/test/kotlin/com/ecommerce/adapter/usecase/OrderUseCaseTest.kt
@@ -89,6 +89,7 @@ class OrderUseCaseTest @Autowired constructor(
     fun whenItemQuantityIs50AndOrdersFor1Item_then50UserWillSucceedBut1UserWillFail() {
         // given
         val totalUser = 51
+
         userFixture.createBulkUsers(totalUser)
         itemFixture.createItemsAndStocks(50L)
 
@@ -115,6 +116,10 @@ class OrderUseCaseTest @Autowired constructor(
         CompletableFuture.allOf(*tasks.toTypedArray()).join()
 
         // then
+        Thread.sleep(3000)
+        val resultStock = stockRepository.findByItemIdWithLock(1L).get()
+        assertThat(resultStock.quantity).isZero()
+
         assertThat(successCount.get()).isEqualTo(50)
         assertThat(failureCount.get()).isOne()
     }

--- a/ecommerce-adapter/src/test/resources/application-test.yml
+++ b/ecommerce-adapter/src/test/resources/application-test.yml
@@ -12,3 +12,8 @@ spring:
     hibernate:
       ddl-auto: create
     show-sql: true
+
+  data:
+    redis:
+      host: localhost
+      port: 6379

--- a/ecommerce-application/src/main/kotlin/com/ecommerce/application/compensation/CompensateOrderService.kt
+++ b/ecommerce-application/src/main/kotlin/com/ecommerce/application/compensation/CompensateOrderService.kt
@@ -1,0 +1,27 @@
+package com.ecommerce.application.compensation
+
+import com.ecommerce.application.port.out.CouponPort
+import com.ecommerce.application.port.out.OrderPort
+import com.ecommerce.domain.order.Order
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+
+@Component
+class CompensateOrderService(
+    private val orderPort: OrderPort,
+    private val couponPort: CouponPort
+) {
+
+    @Transactional
+    fun compensateOrder(order: Order) {
+        // 1. 쿠폰 사용 복구
+        order.couponId?.let {
+            couponPort.rollbackUserCoupon(it, order.userId)
+        }
+
+        // 2. 주문 상태 취소 처리
+        order.cancel()
+        orderPort.commandOrder(order)
+    }
+
+}

--- a/ecommerce-application/src/main/kotlin/com/ecommerce/application/event/DeductStockEventListener.kt
+++ b/ecommerce-application/src/main/kotlin/com/ecommerce/application/event/DeductStockEventListener.kt
@@ -2,7 +2,6 @@ package com.ecommerce.application.event
 
 import com.ecommerce.application.port.out.ItemPort
 import com.ecommerce.application.port.out.StockPort
-import com.ecommerce.common.lock.DistributeLockExecutor
 import com.ecommerce.domain.event.DeductStockEvent
 import org.springframework.stereotype.Component
 import org.springframework.transaction.event.TransactionPhase
@@ -11,32 +10,22 @@ import org.springframework.transaction.event.TransactionalEventListener
 @Component
 class DeductStockEventListener(
     private val itemPort: ItemPort,
-    private val stockPort: StockPort,
-    private val lockExecutor: DistributeLockExecutor
+    private val stockPort: StockPort
 ) {
 
     @TransactionalEventListener(phase = TransactionPhase.BEFORE_COMMIT)
     fun deductStock(event: DeductStockEvent) {
-        val itemOfId = event.items.associateBy { it.id }
+        val orderItem = event.orderItem
 
-        event.orderItems.forEach {
-            // TODO 상품 Id 별 분산락 적용
-            lockExecutor.lockWithTransaction(
-                "deductStock-${it.itemId}",
-                5L,
-                3L
-            ) {
-                val stock = stockPort.findStockByItemId(it.itemId)
+        val stock = stockPort.findStockByItemId(orderItem.itemId)
 
-                if (stock.deduct(it.quantity) == 0L) {
-                    val item = itemOfId[it.itemId]!!
-                    item.soldOut()
-                    itemPort.updateItem(item)
-                }
-
-                stockPort.deductStock(stock)
-            }
+        if (stock.deduct(orderItem.quantity) == 0L) {
+            val item = event.item
+            item.soldOut()
+            itemPort.updateItem(item)
         }
+
+        stockPort.deductStock(stock)
     }
 
 }

--- a/ecommerce-application/src/main/kotlin/com/ecommerce/application/event/DeductStockEventListener.kt
+++ b/ecommerce-application/src/main/kotlin/com/ecommerce/application/event/DeductStockEventListener.kt
@@ -1,8 +1,12 @@
 package com.ecommerce.application.event
 
+import com.ecommerce.application.compensation.CompensateOrderService
 import com.ecommerce.application.port.out.ItemPort
+import com.ecommerce.application.port.out.OrderPort
 import com.ecommerce.application.port.out.StockPort
+import com.ecommerce.common.lock.DistributeLockExecutor
 import com.ecommerce.domain.event.DeductStockEvent
+import org.springframework.scheduling.annotation.Async
 import org.springframework.stereotype.Component
 import org.springframework.transaction.event.TransactionPhase
 import org.springframework.transaction.event.TransactionalEventListener
@@ -10,22 +14,41 @@ import org.springframework.transaction.event.TransactionalEventListener
 @Component
 class DeductStockEventListener(
     private val itemPort: ItemPort,
-    private val stockPort: StockPort
+    private val stockPort: StockPort,
+    private val orderPort: OrderPort,
+    private val compensateOrderService: CompensateOrderService,
+    private val lockExecutor: DistributeLockExecutor
 ) {
 
-    @TransactionalEventListener(phase = TransactionPhase.BEFORE_COMMIT)
+    @Async("eventTaskExecutor")
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     fun deductStock(event: DeductStockEvent) {
-        val orderItem = event.orderItem
+        val order = event.order
+        val itemOfId = event.items.associateBy { it.id }
 
-        val stock = stockPort.findStockByItemId(orderItem.itemId)
+        try {
+            order.orderItems.forEach {
+                lockExecutor.lockWithTransaction(
+                    "deductStock-${it.itemId}", 5L, 3L
+                ) {
+                    val stock = stockPort.findStockByItemId(it.itemId)
 
-        if (stock.deduct(orderItem.quantity) == 0L) {
-            val item = event.item
-            item.soldOut()
-            itemPort.updateItem(item)
+                    if (stock.deduct(it.quantity) == 0L) {
+                        val item = itemOfId[it.itemId]!!
+                        item.soldOut()
+                        itemPort.updateItem(item)
+                    }
+
+                    stockPort.deductStock(stock)
+                }
+            }
+
+            order.complete()
+            orderPort.commandOrder(order)
+        } catch (e: Exception) {
+            // 보상 트랜잭션 - 쿠폰 사용 취소 , 주문 취소
+            compensateOrderService.compensateOrder(order)
         }
-
-        stockPort.deductStock(stock)
     }
 
 }

--- a/ecommerce-application/src/main/kotlin/com/ecommerce/application/event/DeductStockEventListener.kt
+++ b/ecommerce-application/src/main/kotlin/com/ecommerce/application/event/DeductStockEventListener.kt
@@ -2,6 +2,7 @@ package com.ecommerce.application.event
 
 import com.ecommerce.application.port.out.ItemPort
 import com.ecommerce.application.port.out.StockPort
+import com.ecommerce.common.lock.DistributeLockExecutor
 import com.ecommerce.domain.event.DeductStockEvent
 import org.springframework.stereotype.Component
 import org.springframework.transaction.event.TransactionPhase
@@ -10,7 +11,8 @@ import org.springframework.transaction.event.TransactionalEventListener
 @Component
 class DeductStockEventListener(
     private val itemPort: ItemPort,
-    private val stockPort: StockPort
+    private val stockPort: StockPort,
+    private val lockExecutor: DistributeLockExecutor
 ) {
 
     @TransactionalEventListener(phase = TransactionPhase.BEFORE_COMMIT)
@@ -18,15 +20,22 @@ class DeductStockEventListener(
         val itemOfId = event.items.associateBy { it.id }
 
         event.orderItems.forEach {
-            val stock = stockPort.findStockByItemId(it.itemId)
+            // TODO 상품 Id 별 분산락 적용
+            lockExecutor.lockWithTransaction(
+                "deductStock-${it.itemId}",
+                5L,
+                3L
+            ) {
+                val stock = stockPort.findStockByItemId(it.itemId)
 
-            if (stock.deduct(it.quantity) == 0L) {
-                val item = itemOfId[it.itemId]!!
-                item.soldOut()
-                itemPort.updateItem(item)
+                if (stock.deduct(it.quantity) == 0L) {
+                    val item = itemOfId[it.itemId]!!
+                    item.soldOut()
+                    itemPort.updateItem(item)
+                }
+
+                stockPort.deductStock(stock)
             }
-
-            stockPort.deductStock(stock)
         }
     }
 

--- a/ecommerce-application/src/main/kotlin/com/ecommerce/application/port/out/CouponPort.kt
+++ b/ecommerce-application/src/main/kotlin/com/ecommerce/application/port/out/CouponPort.kt
@@ -15,4 +15,6 @@ interface CouponPort {
 
     fun commandUserCoupon(userCoupon: UserCoupon): UserCoupon
 
+    fun rollbackUserCoupon(couponId: Long, userId: Long)
+
 }

--- a/ecommerce-application/src/main/kotlin/com/ecommerce/application/service/CouponService.kt
+++ b/ecommerce-application/src/main/kotlin/com/ecommerce/application/service/CouponService.kt
@@ -3,36 +3,38 @@ package com.ecommerce.application.service
 import com.ecommerce.application.dto.CouponCommand
 import com.ecommerce.application.port.`in`.CouponUseCase
 import com.ecommerce.application.port.out.CouponPort
-import com.ecommerce.application.port.out.UserPort
 import com.ecommerce.common.exception.CustomException
 import com.ecommerce.common.exception.ErrorCode
+import com.ecommerce.common.lock.DistributeLockExecutor
 import com.ecommerce.domain.coupon.UserCoupon
+import org.springframework.dao.DataIntegrityViolationException
 import org.springframework.stereotype.Service
-import org.springframework.transaction.annotation.Transactional
 
 @Service
 class CouponService(
     private val couponPort: CouponPort,
-    private val userPort: UserPort
+    private val lockExecutor: DistributeLockExecutor
 ): CouponUseCase {
 
-    @Transactional
     override fun issued(couponCommand: CouponCommand): UserCoupon {
-        // 사용자, 쿠폰 검증
-        val coupon = couponPort.findCouponById(couponCommand.couponId)
-        val user = userPort.findUserById(couponCommand.userId)
+        return lockExecutor.lockWithTransaction(
+            "issuedCoupon-${couponCommand.couponId}",
+            5L,
+            3L
+        ) {
+            // 사용자, 쿠폰 검증
+            val coupon = couponPort.findCouponById(couponCommand.couponId)
 
-        if (couponPort.isExistsUserCoupon(couponCommand.couponId, couponCommand.userId)) {
-            throw CustomException(ErrorCode.COUPON_ALREADY_ISSUED)
+            // 쿠폰 재고 차감
+            couponPort.commandCoupon(coupon.deduct())
+
+            try {
+                couponPort.commandUserCoupon(UserCoupon.register(couponCommand.userId, coupon))
+            } catch (e: DataIntegrityViolationException) {
+                // 유니크 제약 위반 → 중복 발급
+                throw CustomException(ErrorCode.COUPON_ALREADY_ISSUED)
+            }
         }
-
-        // 쿠폰 재고 차감
-        couponPort.commandCoupon(coupon.deduct())
-
-        // 발급 쿠폰 저장
-        return couponPort.commandUserCoupon(
-            UserCoupon.register(user.id!!, coupon)
-        )
     }
 
 }

--- a/ecommerce-application/src/main/kotlin/com/ecommerce/application/service/OrderService.kt
+++ b/ecommerce-application/src/main/kotlin/com/ecommerce/application/service/OrderService.kt
@@ -30,15 +30,19 @@ class OrderService(
         order.calculateOriginPrice(items)
 
         order.couponId?.let {
-            val userCoupon = couponPort.findUserCouponBy(order.couponId!!, order.userId)
-            couponPort.commandUserCoupon(userCoupon.use())
-
-            order.calculateDiscountPrice(userCoupon.coupon)
+            applyCouponTo(order)
         }
 
         eventPublisher.publishEvent(DeductStockEvent(items, orderItems))
-        
+
         return orderPort.commandOrder(order)
+    }
+
+    private fun applyCouponTo(order: Order) {
+        val userCoupon = couponPort.findUserCouponBy(order.couponId!!, order.userId)
+        couponPort.commandUserCoupon(userCoupon.use())
+
+        order.calculateDiscountPrice(userCoupon.coupon)
     }
 
 }

--- a/ecommerce-application/src/main/kotlin/com/ecommerce/application/service/OrderService.kt
+++ b/ecommerce-application/src/main/kotlin/com/ecommerce/application/service/OrderService.kt
@@ -5,35 +5,27 @@ import com.ecommerce.application.port.`in`.OrderUseCase
 import com.ecommerce.application.port.out.CouponPort
 import com.ecommerce.application.port.out.ItemPort
 import com.ecommerce.application.port.out.OrderPort
-import com.ecommerce.common.lock.DistributeLockExecutor
 import com.ecommerce.domain.event.DeductStockEvent
 import com.ecommerce.domain.order.Order
 import org.springframework.context.ApplicationEventPublisher
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
 
 @Service
 class OrderService(
     private val orderPort: OrderPort,
     private val itemPort: ItemPort,
     private val couponPort: CouponPort,
-    private val eventPublisher: ApplicationEventPublisher,
-    private val lockExecutor: DistributeLockExecutor
+    private val eventPublisher: ApplicationEventPublisher
 ): OrderUseCase {
 
+    @Transactional
     override fun placeOrder(orderCommand: OrderCommand): Order {
-        val order = orderCommand.toOrder()
+        var order = orderCommand.toOrder()
         val orderItems = order.orderItems
 
         val items = itemPort.getItemsIn(orderItems.map { it.itemId })
         items.forEach { it.isSelling() }
-
-        // 재고 차감 로직 이벤트 처리
-        val itemOfId = items.associateBy { it.id }
-        orderItems.forEach {
-            lockExecutor.lockWithTransaction("deductStock-${it.itemId}", 5L, 3L) {
-                eventPublisher.publishEvent(DeductStockEvent(it, itemOfId[it.itemId]!!))
-            }
-        }
 
         order.calculateOriginPrice(items)
 
@@ -41,7 +33,12 @@ class OrderService(
             applyCouponTo(order)
         }
 
-        return orderPort.commandOrder(order)
+        order = orderPort.commandOrder(order)
+
+        // 재고 차감 로직 이벤트 처리
+        eventPublisher.publishEvent(DeductStockEvent(items, order))
+
+        return order
     }
 
     private fun applyCouponTo(order: Order) {

--- a/ecommerce-application/src/main/kotlin/com/ecommerce/application/service/OrderService.kt
+++ b/ecommerce-application/src/main/kotlin/com/ecommerce/application/service/OrderService.kt
@@ -5,21 +5,21 @@ import com.ecommerce.application.port.`in`.OrderUseCase
 import com.ecommerce.application.port.out.CouponPort
 import com.ecommerce.application.port.out.ItemPort
 import com.ecommerce.application.port.out.OrderPort
+import com.ecommerce.common.lock.DistributeLockExecutor
 import com.ecommerce.domain.event.DeductStockEvent
 import com.ecommerce.domain.order.Order
 import org.springframework.context.ApplicationEventPublisher
 import org.springframework.stereotype.Service
-import org.springframework.transaction.annotation.Transactional
 
 @Service
 class OrderService(
     private val orderPort: OrderPort,
     private val itemPort: ItemPort,
     private val couponPort: CouponPort,
-    private val eventPublisher: ApplicationEventPublisher
+    private val eventPublisher: ApplicationEventPublisher,
+    private val lockExecutor: DistributeLockExecutor
 ): OrderUseCase {
 
-    @Transactional
     override fun placeOrder(orderCommand: OrderCommand): Order {
         val order = orderCommand.toOrder()
         val orderItems = order.orderItems
@@ -27,14 +27,19 @@ class OrderService(
         val items = itemPort.getItemsIn(orderItems.map { it.itemId })
         items.forEach { it.isSelling() }
 
+        // 재고 차감 로직 이벤트 처리
+        val itemOfId = items.associateBy { it.id }
+        orderItems.forEach {
+            lockExecutor.lockWithTransaction("deductStock-${it.itemId}", 5L, 3L) {
+                eventPublisher.publishEvent(DeductStockEvent(it, itemOfId[it.itemId]!!))
+            }
+        }
+
         order.calculateOriginPrice(items)
 
         order.couponId?.let {
             applyCouponTo(order)
         }
-
-        // TODO 재고 차감 로직 이벤트 처리
-        eventPublisher.publishEvent(DeductStockEvent(items, orderItems))
 
         return orderPort.commandOrder(order)
     }

--- a/ecommerce-application/src/main/kotlin/com/ecommerce/application/service/OrderService.kt
+++ b/ecommerce-application/src/main/kotlin/com/ecommerce/application/service/OrderService.kt
@@ -33,6 +33,7 @@ class OrderService(
             applyCouponTo(order)
         }
 
+        // TODO 재고 차감 로직 이벤트 처리
         eventPublisher.publishEvent(DeductStockEvent(items, orderItems))
 
         return orderPort.commandOrder(order)

--- a/ecommerce-common/build.gradle.kts
+++ b/ecommerce-common/build.gradle.kts
@@ -1,3 +1,4 @@
 dependencies {
-
+    implementation("org.springframework.boot:spring-boot-starter-data-redis")
+    implementation ("org.redisson:redisson-spring-boot-starter:3.47.0")
 }

--- a/ecommerce-common/src/main/kotlin/com/ecommerce/common/config/RedisCleanUp.kt
+++ b/ecommerce-common/src/main/kotlin/com/ecommerce/common/config/RedisCleanUp.kt
@@ -1,0 +1,22 @@
+package com.ecommerce.common.config
+
+import org.slf4j.LoggerFactory
+import org.springframework.data.redis.core.RedisTemplate
+import org.springframework.stereotype.Component
+
+@Component
+class RedisCleanUp(
+    private val redisTemplate: RedisTemplate<String, Any>
+) {
+
+    private val log = LoggerFactory.getLogger(RedisCleanUp::class.java)
+
+    fun execute() {
+        val keys = redisTemplate.keys("*")
+        if (keys.isNotEmpty()) {
+            redisTemplate.delete(keys)
+            log.info("Delete All Keys")
+        }
+    }
+
+}

--- a/ecommerce-common/src/main/kotlin/com/ecommerce/common/config/RedisConfig.kt
+++ b/ecommerce-common/src/main/kotlin/com/ecommerce/common/config/RedisConfig.kt
@@ -1,0 +1,42 @@
+package com.ecommerce.common.config
+
+import org.redisson.Redisson
+import org.redisson.api.RedissonClient
+import org.redisson.config.Config
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.data.redis.connection.RedisConnectionFactory
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory
+import org.springframework.data.redis.core.RedisTemplate
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer
+import org.springframework.data.redis.serializer.StringRedisSerializer
+
+@Configuration
+class RedisConfig(
+    @Value("\${spring.data.redis.host}")
+    val host: String,
+    @Value("\${spring.data.redis.port}")
+    val port: Int
+) {
+
+    @Bean
+    fun redisConnectionFactory(): RedisConnectionFactory = LettuceConnectionFactory(host, port)
+
+    @Bean
+    fun redisTemplate(): RedisTemplate<String, Any> {
+        return RedisTemplate<String, Any>().apply {
+            connectionFactory = redisConnectionFactory()
+            keySerializer = StringRedisSerializer()
+            valueSerializer = GenericJackson2JsonRedisSerializer()
+        }
+    }
+
+    @Bean
+    fun redissonClient(): RedissonClient {
+        val config = Config()
+        config.useSingleServer().setAddress("redis://$host:$port")
+        return Redisson.create(config)
+    }
+
+}

--- a/ecommerce-common/src/main/kotlin/com/ecommerce/common/exception/CustomException.kt
+++ b/ecommerce-common/src/main/kotlin/com/ecommerce/common/exception/CustomException.kt
@@ -2,4 +2,4 @@ package com.ecommerce.common.exception
 
 class CustomException(
     val errorCode: ErrorCode
-): RuntimeException()
+): RuntimeException(errorCode.message)

--- a/ecommerce-common/src/main/kotlin/com/ecommerce/common/lock/DistributeLockExecutor.kt
+++ b/ecommerce-common/src/main/kotlin/com/ecommerce/common/lock/DistributeLockExecutor.kt
@@ -1,0 +1,40 @@
+package com.ecommerce.common.lock
+
+import org.redisson.api.RedissonClient
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Component
+import java.util.concurrent.TimeUnit
+
+@Component
+class DistributeLockExecutor(
+    private val redissonClient: RedissonClient,
+    private val functionalForTransaction: FunctionalForTransaction
+) {
+
+    private val log = LoggerFactory.getLogger(DistributeLockExecutor::class.java)
+
+    fun <T> lockWithTransaction(key: String, waitTime: Long, leaseTime: Long, action: () -> T): T {
+        val rLock = redissonClient.getLock(key)
+        log.info("Start Lock : $key")
+
+        return try {
+            if (!rLock.tryLock(waitTime, leaseTime, TimeUnit.SECONDS)) {
+                throw RuntimeException("락 획득 실패 : $key")
+            }
+
+            functionalForTransaction.proceed(action)
+        } catch (e: InterruptedException) {
+            throw InterruptedException()
+        } finally {
+            try {
+                if (rLock.isLocked && rLock.isHeldByCurrentThread) {
+                    rLock.unlock()
+                    log.info("Finish Lock : $key")
+                }
+            } catch (e: IllegalMonitorStateException) {
+                throw RuntimeException("Already UnLock : $key")
+            }
+        }
+    }
+
+}

--- a/ecommerce-common/src/main/kotlin/com/ecommerce/common/lock/FunctionalForTransaction.kt
+++ b/ecommerce-common/src/main/kotlin/com/ecommerce/common/lock/FunctionalForTransaction.kt
@@ -1,0 +1,15 @@
+package com.ecommerce.common.lock
+
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Propagation
+import org.springframework.transaction.annotation.Transactional
+
+@Component
+class FunctionalForTransaction {
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    fun <T> proceed(action: () -> T): T {
+        return action()
+    }
+
+}

--- a/ecommerce-domain/src/main/kotlin/com/ecommerce/domain/event/DeductStockEvent.kt
+++ b/ecommerce-domain/src/main/kotlin/com/ecommerce/domain/event/DeductStockEvent.kt
@@ -1,9 +1,9 @@
 package com.ecommerce.domain.event
 
 import com.ecommerce.domain.item.Item
-import com.ecommerce.domain.order.OrderItem
+import com.ecommerce.domain.order.Order
 
 data class DeductStockEvent(
-    val orderItem: OrderItem,
-    val item: Item
+    val items: List<Item>,
+    val order: Order
 )

--- a/ecommerce-domain/src/main/kotlin/com/ecommerce/domain/event/DeductStockEvent.kt
+++ b/ecommerce-domain/src/main/kotlin/com/ecommerce/domain/event/DeductStockEvent.kt
@@ -4,6 +4,6 @@ import com.ecommerce.domain.item.Item
 import com.ecommerce.domain.order.OrderItem
 
 data class DeductStockEvent(
-    val items: List<Item>,
-    val orderItems: List<OrderItem>
+    val orderItem: OrderItem,
+    val item: Item
 )

--- a/ecommerce-domain/src/main/kotlin/com/ecommerce/domain/order/Order.kt
+++ b/ecommerce-domain/src/main/kotlin/com/ecommerce/domain/order/Order.kt
@@ -12,11 +12,11 @@ class Order(
     var originPrice: BigDecimal = BigDecimal.ZERO,
     var discountPrice: BigDecimal = BigDecimal.ZERO,
     var totalPrice: BigDecimal = BigDecimal.ZERO,
-    var status: OrderStatus = OrderStatus.ORDERED
+    var status: OrderStatus = OrderStatus.PENDING
 ) {
 
     enum class OrderStatus {
-        ORDERED, PAID, CANCEL
+        PENDING, COMPLETED, PAID, CANCEL
     }
 
     fun calculateOriginPrice(items: List<Item>) {
@@ -37,6 +37,16 @@ class Order(
 
     fun paid(): Order {
         this.status = OrderStatus.PAID
+        return this
+    }
+
+    fun complete(): Order {
+        this.status = OrderStatus.COMPLETED
+        return this
+    }
+
+    fun cancel(): Order {
+        this.status = OrderStatus.CANCEL
         return this
     }
 


### PR DESCRIPTION
- [x] 쿠폰
- [x] 주문

---

### 재고 차감 분산락 적용 시 데이터 정합성 문제 발생
먼저 재고 차감 로직을 이벤트로 분리한 이유는
**주문 메서드 안에 과도한 책임이 주어지기 때문입니다.** -> 코드가 너무 길어지더라구여..
```java
@Transactional
override fun placeOrder(orderCommand: OrderCommand): Order {
    val order = orderCommand.toOrder()
    val orderItems = order.orderItems

    val items = itemPort.getItemsIn(orderItems.map { it.itemId })
    items.forEach { it.isSelling() }

    order.calculateOriginPrice(items)

    order.couponId?.let {
        applyCouponTo(order)
    }

    // TODO 재고 차감 로직 이벤트 처리
    eventPublisher.publishEvent(DeductStockEvent(items, orderItems))

    return orderPort.commandOrder(order)
}
```
주문 메서드에서 재고 차감 이벤트가 발행되면
아래 코드로 재고 차감 로직이 실행됩니다.
```java
@TransactionalEventListener(phase = TransactionPhase.BEFORE_COMMIT)
fun deductStock(event: DeductStockEvent) {
    val itemOfId = event.items.associateBy { it.id }

    event.orderItems.forEach {
        // TODO 상품 Id 별 분산락 적용
        lockExecutor.lockWithTransaction(
            "deductStock-${it.itemId}",
            5L,
            3L
        ) {
            val stock = stockPort.findStockByItemId(it.itemId)

            if (stock.deduct(it.quantity) == 0L) {
                val item = itemOfId[it.itemId]!!
                item.soldOut()
                itemPort.updateItem(item)
            }

            stockPort.deductStock(stock)
        }
    }
}
```
>여기서 적용된 함수형 분산락은
>내부에서 전달받은 키로 락을 걸고 
>REQUIRES_NEW 설정으로 인해 실행되는 로직에 새로운 트랜잭션이 시작됩니다.
>[함수형 분산락 코드 보러가기](https://github.com/scars97/e-commerce/blob/concurrency-control/ecommerce-common/src/main/kotlin/com/ecommerce/common/lock/DistributeLockExecutor.kt)

단순하게 주문 메서드에 분산락 어노테이션 주면 되지 않을까 생각도 했지만
분산락 키를 어떤 것으로 정해야할 지 고민했는데요.

각각 다른 상품들을 n 개씩 주문할 수 있는 환경에서
정산적인 재고 차감을 위해 주문 상품 ID를 분산락 키로 설정했습니다.

위 코드에서는 사용자 주문 상품 데이터를 순회하면서
각 상품ID 마다 분산락을 걸고 상품에 대한 재고 조회/차감을 시도 합니다.

이렇게 로직을 작성하고 동시성 제어 테스트를 했을 때 실패하게 됩니다.

**추측**
주문 메서드 트랜잭션 시작되고 재고차감 락이 적용되어
기존 트랜잭션 -> 락 획득 -> 새로운 트랜잭션 -> 새로운 트랜잭션 종료 -> 락 해제 -> 기존 트랜잭션 종료
이런 식으로 트랜잭션과 락 획득 순서가 꼬여서 발생한 걸로 예상됩니다.