### PR TITLE
[refactor] 인기 상품 조회 방식 변경

### DIFF
--- a/ecommerce-adapter/build.gradle.kts
+++ b/ecommerce-adapter/build.gradle.kts
@@ -17,6 +17,9 @@ dependencies {
     // Mysql
     runtimeOnly("com.mysql:mysql-connector-j")
 
+    // Redis
+    implementation("org.springframework.boot:spring-boot-starter-data-redis")
+
     // TestContainer
     testImplementation ("org.testcontainers:mysql")
     testImplementation ("com.redis:testcontainers-redis")

--- a/ecommerce-adapter/src/main/kotlin/com/ecommerce/adapter/in/controller/ItemController.kt
+++ b/ecommerce-adapter/src/main/kotlin/com/ecommerce/adapter/in/controller/ItemController.kt
@@ -32,7 +32,7 @@ class ItemController(
     fun getPopularItems(
         @RequestParam(value = "period", defaultValue = "3") period: Long
     ): ResponseEntity<List<PopularItemResponse>> {
-        val popularItems = itemUseCase.getPopularItemsOnTop10(period)
+        val popularItems = itemUseCase.getPopularItems(period)
 
         return ResponseEntity.ok(
             popularItems.map { PopularItemResponse.of(it) }.toList()

--- a/ecommerce-adapter/src/main/kotlin/com/ecommerce/adapter/in/dto/response/PopularItemResponse.kt
+++ b/ecommerce-adapter/src/main/kotlin/com/ecommerce/adapter/in/dto/response/PopularItemResponse.kt
@@ -4,7 +4,6 @@ import com.ecommerce.domain.item.PopularItem
 
 data class PopularItemResponse(
     val rank: Int,
-    val cumulativeSales: Long,
     val item: ItemResponse
 ) {
 
@@ -12,7 +11,6 @@ data class PopularItemResponse(
         fun of(popularItem: PopularItem): PopularItemResponse {
             return PopularItemResponse(
                 rank = popularItem.rank,
-                cumulativeSales = popularItem.cumulativeSales,
                 item = ItemResponse.of(popularItem.item)
             )
         }

--- a/ecommerce-adapter/src/main/kotlin/com/ecommerce/adapter/out/persistence/core/ItemPersistenceAdapter.kt
+++ b/ecommerce-adapter/src/main/kotlin/com/ecommerce/adapter/out/persistence/core/ItemPersistenceAdapter.kt
@@ -36,6 +36,13 @@ class ItemPersistenceAdapter(
         return items.map { itemMapper.toItem(it) }
     }
 
+    override fun getItems(itemId: Long): Item {
+        val item = jpaRepository.findById(itemId)
+            .orElseThrow { CustomException(ErrorCode.ITEM_NOT_FOUND) }
+
+        return itemMapper.toItem(item)
+    }
+
     override fun updateItem(item: Item) {
         jpaRepository.save(itemMapper.toItemEntity(item))
     }

--- a/ecommerce-adapter/src/main/kotlin/com/ecommerce/adapter/out/persistence/core/ItemPersistenceAdapter.kt
+++ b/ecommerce-adapter/src/main/kotlin/com/ecommerce/adapter/out/persistence/core/ItemPersistenceAdapter.kt
@@ -8,13 +8,19 @@ import com.ecommerce.common.exception.ErrorCode
 import com.ecommerce.domain.item.Item
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.PageRequest
+import org.springframework.data.redis.core.RedisTemplate
 import org.springframework.stereotype.Repository
 
 @Repository
 class ItemPersistenceAdapter(
     private val itemMapper: ItemMapper,
-    private val jpaRepository: ItemJpaRepository
+    private val jpaRepository: ItemJpaRepository,
+    private val redisTemplate: RedisTemplate<String, String>
 ): ItemPort {
+
+    companion object {
+        const val POPULAR_ITEMS = "popular-items-"
+    }
 
     override fun getItemsByPage(page: Int, size: Int): Page<Item> {
         val items = jpaRepository.findAll(PageRequest.of(page, size))
@@ -32,6 +38,27 @@ class ItemPersistenceAdapter(
 
     override fun updateItem(item: Item) {
         jpaRepository.save(itemMapper.toItemEntity(item))
+    }
+
+    override fun getPopularItemIds(period: Long): List<Long> {
+        val key = POPULAR_ITEMS.plus(period)
+
+        val json = redisTemplate.opsForValue().get(key)
+
+        return if (json != null) {
+            val trimmed = json.removePrefix("[").removeSuffix("]")
+            trimmed.split(",").map { it.trim().toLong() }
+        } else {
+            emptyList()
+        }
+    }
+
+    override fun updatePopularItemRank(period: Long, itemIds: List<Long>) {
+        val key = POPULAR_ITEMS.plus(period)
+
+        val stringItemIds = itemIds.toString()
+
+        redisTemplate.opsForValue().set(key, stringItemIds)
     }
 
 }

--- a/ecommerce-adapter/src/test/kotlin/com/ecommerce/adapter/persistence/ItemPersistenceAdapterTest.kt
+++ b/ecommerce-adapter/src/test/kotlin/com/ecommerce/adapter/persistence/ItemPersistenceAdapterTest.kt
@@ -59,23 +59,28 @@ class ItemPersistenceAdapterTest @Autowired constructor(
         assertThat(result.content).hasSize(1)
     }
 
+    @DisplayName("인기 상품 순위 업데이트 & 조회 테스트")
     @TestFactory
     fun popularItemRankCommandAndQueryTest(): List<DynamicTest> {
+        // given
         val period = 3L
         val redisKey = "popular-items-".plus(period)
+        val itemIds = listOf(1L, 2L, 3L)
 
         return listOf(
             DynamicTest.dynamicTest("인기 상품 순위 업데이트") {
-                val itemIds = listOf(1L, 2L, 3L)
-
+                // when
                 sut.updatePopularItemRank(period, itemIds)
 
+                // then
                 val result = redisTemplate.opsForValue().get(redisKey)
                 assertThat(result).isEqualTo("[1, 2, 3]")
             },
             DynamicTest.dynamicTest("인기 상품 조회") {
+                // when
                 val result = sut.getPopularItemIds(period)
 
+                // then
                 assertThat(result).hasSize(3)
                     .containsExactly(1L, 2L, 3L)
             }

--- a/ecommerce-adapter/src/test/kotlin/com/ecommerce/adapter/service/ItemRankScheduleTest.kt
+++ b/ecommerce-adapter/src/test/kotlin/com/ecommerce/adapter/service/ItemRankScheduleTest.kt
@@ -1,0 +1,39 @@
+package com.ecommerce.adapter.service
+
+import com.ecommerce.adapter.config.IntegrateTestSupport
+import com.ecommerce.adapter.fixture.OrderFixture
+import com.ecommerce.application.port.out.ItemPort
+import com.ecommerce.application.schedule.ItemRankSchedule
+import org.assertj.core.api.Assertions.*
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+
+class ItemRankScheduleTest @Autowired constructor(
+    private val sut: ItemRankSchedule,
+    private val itemPort: ItemPort,
+    private val orderFixture: OrderFixture
+): IntegrateTestSupport() {
+
+    @BeforeEach
+    fun setUp() {
+        orderFixture.placeOrder(OrderFixture.OrderFixtureStatus.BULK)
+    }
+
+    @DisplayName("스케줄러를 통해 특정 기간동안 주문된 상품을 집계하여 인기 상품 순위를 결정한다.")
+    @Test
+    fun whenExecuteScheduler_thenAggregateOrderStatistics() {
+        // given
+        val period = 3L
+
+        // when
+        sut.aggregateOrderStatistics()
+
+        // then
+        val result = itemPort.getPopularItemIds(period)
+        assertThat(result).hasSize(5)
+            .containsExactly(5L, 2L, 1L, 4L, 3L)
+    }
+
+}

--- a/ecommerce-adapter/src/test/kotlin/com/ecommerce/adapter/usecase/ItemUseCaseTest.kt
+++ b/ecommerce-adapter/src/test/kotlin/com/ecommerce/adapter/usecase/ItemUseCaseTest.kt
@@ -3,6 +3,7 @@ package com.ecommerce.adapter.usecase
 import com.ecommerce.adapter.config.IntegrateTestSupport
 import com.ecommerce.adapter.fixture.OrderFixture
 import com.ecommerce.application.port.`in`.ItemUseCase
+import com.ecommerce.application.schedule.ItemRankSchedule
 import org.assertj.core.api.Assertions.*
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -10,6 +11,7 @@ import org.springframework.beans.factory.annotation.Autowired
 
 class ItemUseCaseTest @Autowired constructor(
     private val sut: ItemUseCase,
+    private val rankScheduler: ItemRankSchedule,
     private val orderFixture: OrderFixture
 ): IntegrateTestSupport() {
 
@@ -19,22 +21,23 @@ class ItemUseCaseTest @Autowired constructor(
     }
 
     @Test
-    fun getPopularItemsOnTop10() {
+    fun getPopularItems() {
         // given
         val period = 3L
+        rankScheduler.aggregateOrderStatistics()
 
         // when
-        val popularItems = sut.getPopularItemsOnTop10(period)
+        val result = sut.getPopularItems(period)
 
         // then
-        assertThat(popularItems).hasSize(5)
-            .extracting("rank", "cumulativeSales", "item.id", "item.name")
+        assertThat(result).hasSize(5)
+            .extracting("rank", "item.id", "item.name")
             .containsExactly(
-                tuple(1, 20L, 5L, "상품 E"),
-                tuple(2, 18L, 2L, "상품 B"),
-                tuple(3, 15L, 1L, "상품 A"),
-                tuple(4, 12L, 4L, "상품 D"),
-                tuple(5, 10L, 3L, "상품 C")
+                tuple(1, 5L, "상품 E"),
+                tuple(2, 2L, "상품 B"),
+                tuple(3, 1L, "상품 A"),
+                tuple(4, 4L, "상품 D"),
+                tuple(5, 3L, "상품 C")
             )
     }
 

--- a/ecommerce-application/src/main/kotlin/com/ecommerce/application/port/in/ItemUseCase.kt
+++ b/ecommerce-application/src/main/kotlin/com/ecommerce/application/port/in/ItemUseCase.kt
@@ -8,6 +8,6 @@ interface ItemUseCase {
 
     fun getItems(page: Int, size: Int): Page<Item>
 
-    fun getPopularItemsOnTop10(period: Long): List<PopularItem>
+    fun getPopularItems(period: Long): List<PopularItem>
 
 }

--- a/ecommerce-application/src/main/kotlin/com/ecommerce/application/port/out/ItemPort.kt
+++ b/ecommerce-application/src/main/kotlin/com/ecommerce/application/port/out/ItemPort.kt
@@ -11,4 +11,8 @@ interface ItemPort {
 
     fun updateItem(item: Item)
 
+    fun getPopularItemIds(period: Long): List<Long>
+
+    fun updatePopularItemRank(period: Long, itemIds: List<Long>)
+
 }

--- a/ecommerce-application/src/main/kotlin/com/ecommerce/application/port/out/ItemPort.kt
+++ b/ecommerce-application/src/main/kotlin/com/ecommerce/application/port/out/ItemPort.kt
@@ -9,6 +9,8 @@ interface ItemPort {
 
     fun getItemsIn(itemIds: List<Long>): List<Item>
 
+    fun getItems(itemId: Long): Item
+
     fun updateItem(item: Item)
 
     fun getPopularItemIds(period: Long): List<Long>

--- a/ecommerce-application/src/main/kotlin/com/ecommerce/application/schedule/ItemRankSchedule.kt
+++ b/ecommerce-application/src/main/kotlin/com/ecommerce/application/schedule/ItemRankSchedule.kt
@@ -1,0 +1,43 @@
+package com.ecommerce.application.schedule
+
+import com.ecommerce.application.port.out.ItemPort
+import com.ecommerce.application.port.out.OrderItemPort
+import com.ecommerce.domain.order.OrderItem
+import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.stereotype.Component
+
+@Component
+class ItemRankSchedule(
+    private val orderItemPort: OrderItemPort,
+    private val itemPort: ItemPort
+) {
+
+    companion object {
+        val PERIOD_LIST = listOf(3L, 7L)
+    }
+
+    @Scheduled(cron = "0 0 0 * * *")
+    fun aggregateOrderStatistics() {
+        PERIOD_LIST.forEach {
+            // 특정 기간동안 주문된 상품 조회
+            val orderItemsByPeriod = orderItemPort.getOrderItemsByPeriod(it)
+
+            // 주문 수량이 많은 순으로 정렬
+            val sortedPopularItemIds = deduplicateAfterCalculateTotalQuantity(orderItemsByPeriod)
+
+            // 인기 상품 ID 저장
+            itemPort.updatePopularItemRank(it, sortedPopularItemIds)
+        }
+    }
+
+    private fun deduplicateAfterCalculateTotalQuantity(orderItemsByPeriod: List<OrderItem>) =
+        orderItemsByPeriod
+            .groupBy { it.itemId }
+            .map { (itemId, items) ->
+                val totalQuantity = items.sumOf { it.quantity }
+                OrderItem(null, itemId, totalQuantity)
+            }
+            .sortedByDescending { it.quantity }
+            .map { it.itemId }
+
+}

--- a/ecommerce-application/src/main/kotlin/com/ecommerce/application/service/ItemService.kt
+++ b/ecommerce-application/src/main/kotlin/com/ecommerce/application/service/ItemService.kt
@@ -5,7 +5,6 @@ import com.ecommerce.application.port.out.ItemPort
 import com.ecommerce.application.port.out.OrderItemPort
 import com.ecommerce.domain.item.Item
 import com.ecommerce.domain.item.PopularItem
-import com.ecommerce.domain.order.OrderItem
 import org.springframework.data.domain.Page
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -25,44 +24,21 @@ class ItemService(
         return itemPort.getItemsByPage(page, size)
     }
 
-    override fun getPopularItemsOnTop10(period: Long): List<PopularItem> {
-        // period 만큼 주문 상품 전체 조회
-        val orderItemsByPeriod = orderItemPort.getOrderItemsByPeriod(period)
+    override fun getPopularItems(period: Long): List<PopularItem> {
+        val itemIds = itemPort.getPopularItemIds(period)
 
-        // 중복 제거 후, 주문 수량 합 계산
-        val orderItems = deduplicateAfterCalculateTotalQuantity(orderItemsByPeriod)
+        val items = itemIds.map { itemPort.getItems(it) }.toList()
 
-        // 정렬된 주문 상품의 id로 실제 상품 조회
-        val items = itemPort.getItemsIn(
-            orderItems.map { it.itemId }
-        )
-
-        // 인기 상품 변환
-        return convertPopularItems(items, orderItems)
+        return convertPopularItems(items)
     }
 
-    private fun convertPopularItems(
-        items: List<Item>,
-        orderItems: List<OrderItem>
-    ): List<PopularItem> {
-        val itemOfId = items.associateBy { it.id }
-        return orderItems.mapIndexed { index, item ->
+    private fun convertPopularItems(items: List<Item>): List<PopularItem> {
+        return items.mapIndexed { index, item ->
             PopularItem(
                 rank = index + 1,
-                cumulativeSales = item.quantity,
-                item = itemOfId[item.itemId]!!
+                item = item
             )
         }
     }
-
-    private fun deduplicateAfterCalculateTotalQuantity(orderItemsByPeriod: List<OrderItem>) =
-        orderItemsByPeriod
-            .groupBy { it.itemId }
-            .map { (itemId, items) ->
-                val totalQuantity = items.sumOf { it.quantity }
-                OrderItem(null, itemId, totalQuantity)
-            }
-            .sortedByDescending { it.quantity }
-            .take(ITEM_LIMIT)
 
 }

--- a/ecommerce-common/src/main/kotlin/com/ecommerce/common/config/RedisCleanUp.kt
+++ b/ecommerce-common/src/main/kotlin/com/ecommerce/common/config/RedisCleanUp.kt
@@ -6,7 +6,7 @@ import org.springframework.stereotype.Component
 
 @Component
 class RedisCleanUp(
-    private val redisTemplate: RedisTemplate<String, Any>
+    private val redisTemplate: RedisTemplate<String, String>
 ) {
 
     private val log = LoggerFactory.getLogger(RedisCleanUp::class.java)

--- a/ecommerce-common/src/main/kotlin/com/ecommerce/common/config/RedisConfig.kt
+++ b/ecommerce-common/src/main/kotlin/com/ecommerce/common/config/RedisConfig.kt
@@ -9,7 +9,6 @@ import org.springframework.context.annotation.Configuration
 import org.springframework.data.redis.connection.RedisConnectionFactory
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory
 import org.springframework.data.redis.core.RedisTemplate
-import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer
 import org.springframework.data.redis.serializer.StringRedisSerializer
 
 @Configuration
@@ -24,11 +23,11 @@ class RedisConfig(
     fun redisConnectionFactory(): RedisConnectionFactory = LettuceConnectionFactory(host, port)
 
     @Bean
-    fun redisTemplate(): RedisTemplate<String, Any> {
-        return RedisTemplate<String, Any>().apply {
+    fun redisTemplate(): RedisTemplate<String, String> {
+        return RedisTemplate<String, String>().apply {
             connectionFactory = redisConnectionFactory()
             keySerializer = StringRedisSerializer()
-            valueSerializer = GenericJackson2JsonRedisSerializer()
+            valueSerializer = StringRedisSerializer()
         }
     }
 

--- a/ecommerce-domain/src/main/kotlin/com/ecommerce/domain/item/PopularItem.kt
+++ b/ecommerce-domain/src/main/kotlin/com/ecommerce/domain/item/PopularItem.kt
@@ -2,6 +2,5 @@ package com.ecommerce.domain.item
 
 class PopularItem(
     val rank: Int,
-    val cumulativeSales: Long,
     val item: Item
 )


### PR DESCRIPTION
### 작업 이슈
- #8 

### AS-IS
- 특정 기간동안 주문된 상품 데이터 조회
- 애플리케이션 레벨에서 인기 상품 순위 정렬 작업 수행
```kotlin
override fun getPopularItemsOnTop10(period: Long): List<PopularItem> {
    // period 만큼 주문 상품 전체 조회

    // 중복 제거 후, 주문 수량 합 계산

    // 정렬된 주문 상품의 id로 실제 상품 조회

    // 인기 상품 변환
}
```

### TO-BE
- 스케줄러를 활용하여 특정 기간동안 주문된 상품 데이터 집계 후 저장
    - 스케줄러에서 인기 상품 순위 정렬 작업 수행
    - 레디스에 상품 ID 만 저장
- 레디스에서 인기 상품 ID 조회 후 DB 조회 
```kotlin
override fun getPopularItems(period: Long): List<PopularItem> {
    // 레디스에서 인기 상품 ID 조회

    // 인기 상품 ID로 실제 상품 조회

    // 인기 상품 변환
}
```

---

인기 상품을 조회할 때마다 수행되는 순위 정렬 작업이 스케줄러로 이동
- CPU 작업을 줄일 수 있을 것으로 예상